### PR TITLE
Configure TailwindCSS and base styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,11 @@
   },
   "devDependencies": {
     "eslint": "^8.57.0",
-    "eslint-config-next": "^14.2.0"
+    "eslint-config-next": "^14.2.0",
+    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.16",
+    "@tailwindcss/forms": "^0.5.7",
+    "@tailwindcss/container-queries": "^0.1.1"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 * {
   box-sizing: border-box;
   padding: 0;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,28 @@
+import type { Config } from "tailwindcss";
+import forms from "@tailwindcss/forms";
+import containerQueries from "@tailwindcss/container-queries";
+
+const config: Config = {
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        primary: "#1976d2",
+        surface1: "#121212",
+        surface2: "#1e1e1e",
+        textPrimary: "#ffffff",
+        textSecondary: "#b3b3b3",
+        borderDashed: "#ccc"
+      },
+      fontFamily: {
+        sans: ["Spline Sans", "Noto Sans", "sans-serif"],
+      },
+      borderRadius: {
+        full: "9999px",
+      },
+    },
+  },
+  plugins: [forms, containerQueries],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add Tailwind config with custom colors, fonts, and plugins
- wire Tailwind into global styles and PostCSS
- declare Tailwind and related plugins in dev dependencies

## Testing
- `npm run lint`
- `npm run dev` *(fails: Cannot find module 'tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_68ade346bfbc8330b0f594d4d53aeffc