### PR TITLE
feat: centralize theme configuration

### DIFF
--- a/src/app/components/ThemeProvider.tsx
+++ b/src/app/components/ThemeProvider.tsx
@@ -3,26 +3,7 @@
 import React from "react";
 import { ThemeProvider as MuiThemeProvider } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
-import { createTheme } from "@mui/material/styles";
-
-const theme = createTheme({
-  palette: {
-    mode: "dark",
-    primary: {
-      main: "#1976d2",
-    },
-    secondary: {
-      main: "#dc004e",
-    },
-    background: {
-      default: "#121212",
-      paper: "#1e1e1e",
-    },
-  },
-  typography: {
-    fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
-  },
-});
+import theme from "../../theme";
 
 interface ThemeProviderProps {
   children: React.ReactNode;
@@ -36,3 +17,4 @@ export default function ThemeProvider({ children }: ThemeProviderProps) {
     </MuiThemeProvider>
   );
 }
+

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,57 @@
+import { createTheme } from "@mui/material/styles";
+
+const theme = createTheme({
+  palette: {
+    mode: "dark",
+    primary: {
+      main: "#382929",
+    },
+    background: {
+      default: "#181111",
+      paper: "#382929",
+    },
+    text: {
+      primary: "#FFFFFF",
+      secondary: "#b89d9f",
+    },
+    divider: "#382929",
+  },
+  typography: {
+    fontFamily: '"Spline Sans","Noto Sans",sans-serif',
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: "9999px",
+          backgroundColor: "#382929",
+          color: "#FFFFFF",
+          textTransform: "none",
+          '&:hover': {
+            backgroundColor: "#4b3a3a",
+          },
+        },
+      },
+    },
+    MuiChip: {
+      styleOverrides: {
+        root: {
+          borderRadius: "9999px",
+          backgroundColor: "#382929",
+          color: "#FFFFFF",
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          borderRadius: "16px",
+          backgroundColor: "#382929",
+        },
+      },
+    },
+  },
+});
+
+export default theme;
+


### PR DESCRIPTION
## Summary
- centralize theme setup using MUI createTheme
- apply custom dark palette and rounded component overrides

## Testing
- `npx next lint`


------
https://chatgpt.com/codex/tasks/task_e_68ade482cda88330839e0370d0698c51