### PR TITLE
feat: add analyze document UI components

### DIFF
--- a/src/app/analyze/page.tsx
+++ b/src/app/analyze/page.tsx
@@ -1,119 +1,38 @@
 "use client";
 
-import React, { useState } from "react";
-import { Box, Container, Typography, Button, Alert, Paper } from "@mui/material";
-import { CloudUpload } from "@mui/icons-material";
+import { useState } from "react";
+import Header from "@/components/Header";
+import UploadDropzone from "@/components/UploadDropzone";
+import KeywordPanel from "@/components/KeywordPanel";
 
 export default function AnalyzePage() {
-  const [loading, setLoading] = useState<boolean>(false);
-  const [error, setError] = useState<string | null>(null);
-  const [keywords, setKeywords] = useState<any[]>([]);
+  const [keywords, setKeywords] = useState<string[]>([]);
 
-  const handleFileUpload = async (file: File) => {
-    try {
-      setError(null);
-      setLoading(true);
-
-      // Prepare form data
-      const formData = new FormData();
-      formData.append("file", file);
-      formData.append("mode", "generic");
-
-      // Call API
-      const response = await fetch("/api/analyze", {
-        method: "POST",
-        body: formData,
-      });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || "Error analyzing document");
-      }
-
-      setKeywords(data.keywords || []);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Error analyzing document");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (file) {
-      handleFileUpload(file);
-    }
+  const handleFileUpload = (file: File) => {
+    // simulate async extraction
+    setKeywords([]);
+    setTimeout(() => {
+      setKeywords(["IA", "Modelo", "Documento", "Análisis", "Extracción"]);
+    }, 800);
   };
 
   return (
-    <Box sx={{ minHeight: "100vh", backgroundColor: "#121212", p: 4 }}>
-      <Container maxWidth="lg">
-        <Typography variant="h3" color="white" gutterBottom>
-          DocuMind - Análisis de Documentos
-        </Typography>
-
-        {/* Error Alert */}
-        {error && (
-          <Alert severity="error" sx={{ mb: 3 }} onClose={() => setError(null)}>
-            {error}
-          </Alert>
-        )}
-
-        {/* Upload Section */}
-        <Paper sx={{ p: 4, mb: 4 }}>
-          <Typography variant="h5" gutterBottom>
-            Subir Documento PDF
-          </Typography>
-          <Box sx={{ textAlign: "center" }}>
-            <Button
-              variant="contained"
-              component="label"
-              startIcon={<CloudUpload />}
-              disabled={loading}
-              size="large"
-            >
-              {loading ? "Analizando..." : "Seleccionar PDF"}
-              <input
-                type="file"
-                accept="application/pdf"
-                onChange={handleFileChange}
-                style={{ display: "none" }}
-              />
-            </Button>
-          </Box>
-        </Paper>
-
-        {/* Keywords Section */}
-        <Paper sx={{ p: 4 }}>
-          <Typography variant="h5" gutterBottom>
-            Palabras Clave Extraídas
-          </Typography>
-          {keywords.length === 0 ? (
-            <Typography color="text.secondary">
-              No hay palabras clave. Sube un PDF para comenzar el análisis.
-            </Typography>
-          ) : (
-            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
-              {keywords.map((keyword, index) => (
-                <Box
-                  key={index}
-                  sx={{
-                    px: 2,
-                    py: 1,
-                    backgroundColor: "primary.main",
-                    color: "white",
-                    borderRadius: 1,
-                    fontSize: "0.875rem"
-                  }}
-                >
-                  {keyword.phrase} ({keyword.kind || "other"})
-                </Box>
-              ))}
-            </Box>
-          )}
-        </Paper>
-      </Container>
-    </Box>
+    <div className="min-h-screen flex flex-col bg-primary text-textPrimary">
+      <Header />
+      <div className="gap-1 px-6 flex flex-1 justify-center py-5 flex-col lg:flex-row">
+        <main className="flex flex-col max-w-[920px] flex-1">
+          <div className="flex flex-wrap justify-between gap-3 p-4">
+            <p className="text-[32px] font-bold leading-tight tracking-tight min-w-72">Analizar Documento</p>
+          </div>
+          <div className="flex flex-col p-4">
+            <UploadDropzone onFileUpload={handleFileUpload} />
+          </div>
+          <p className="text-textSecondary text-sm font-normal leading-normal pb-3 pt-1 px-4 text-center">
+            Formatos de archivo admitidos: PDF
+          </p>
+        </main>
+        <KeywordPanel keywords={keywords} />
+      </div>
+    </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,6 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import ThemeProvider from "./components/ThemeProvider";
 import "./globals.css";
-
-const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "DocuMind - Análisis de Documentos PDF",
@@ -17,10 +14,8 @@ export default function RootLayout({
 }) {
   return (
     <html lang="es">
-      <body className={inter.className}>
-        <ThemeProvider>
-          {children}
-        </ThemeProvider>
+      <body className="bg-primary text-textPrimary font-sans">
+        <ThemeProvider>{children}</ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link";
+
+export default function Header() {
+  return (
+    <header className="flex items-center justify-between whitespace-nowrap border-b border-b-[#382929] px-10 py-3">
+      <div className="flex items-center gap-4 text-textPrimary">
+        <div className="size-4" aria-hidden>
+          <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M24 18.4228L42 11.475V34.3663C42 34.7796 41.7457 35.1504 41.3601 35.2992L24 42V18.4228Z"
+              fill="currentColor"
+            ></path>
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M24 8.18819L33.4123 11.574L24 15.2071L14.5877 11.574L24 8.18819ZM9 15.8487L21 20.4805V37.6263L9 32.9945V15.8487ZM27 37.6263V20.4805L39 15.8487V32.9945L27 37.6263ZM25.354 2.29885C24.4788 1.98402 23.5212 1.98402 22.646 2.29885L4.98454 8.65208C3.7939 9.08038 3 10.2097 3 11.475V34.3663C3 36.0196 4.01719 37.5026 5.55962 38.098L22.9197 44.7987C23.6149 45.0671 24.3851 45.0671 25.0803 44.7987L42.4404 38.098C43.9828 37.5026 45 36.0196 45 34.3663V11.475C45 10.2097 44.2061 9.08038 43.0155 8.65208L25.354 2.29885Z"
+              fill="currentColor"
+            ></path>
+          </svg>
+        </div>
+        <h2 className="text-lg font-bold leading-tight tracking-[-0.015em]">DocuMind</h2>
+      </div>
+      <div className="flex flex-1 justify-end gap-8">
+        <nav className="flex items-center gap-9">
+          {['Inicio','Documentos','Ayuda'].map((item) => (
+            <Link key={item} href="#" className="text-sm font-medium leading-normal text-textPrimary">
+              {item}
+            </Link>
+          ))}
+        </nav>
+        <button
+          className="flex size-10 items-center justify-center rounded-full bg-surface1 text-textPrimary transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-textPrimary/30"
+          aria-label="Ayuda"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 256 256">
+            <path d="M140,180a12,12,0,1,1-12-12A12,12,0,0,1,140,180ZM128,72c-22.06,0-40,16.15-40,36v4a8,8,0,0,0,16,0v-4c0-11,10.77-20,24-20s24,9,24,20-10.77,20-24,20a8,8,0,0,0-8,8v8a8,8,0,0,0,16,0v-.72c18.24-3.35,32-17.9,32-35.28C168,88.15,150.06,72,128,72Zm104,56A104,104,0,1,1,128,24,104.11,104.11,0,0,1,232,128Zm-16,0a88,88,0,1,0-88,88A88.1,88.1,0,0,0,216,128Z" />
+          </svg>
+        </button>
+        <div
+          className="size-10 rounded-full bg-cover bg-center"
+          style={{ backgroundImage: 'url("https://i.pravatar.cc/80")' }}
+          aria-label="Perfil"
+        />
+      </div>
+    </header>
+  );
+}

--- a/src/components/KeywordPanel.tsx
+++ b/src/components/KeywordPanel.tsx
@@ -1,0 +1,46 @@
+interface KeywordPanelProps {
+  keywords: string[];
+}
+
+export default function KeywordPanel({ keywords }: KeywordPanelProps) {
+  const hasKeywords = keywords.length > 0;
+  const defaultImage = "https://lh3.googleusercontent.com/aida-public/AB6AXuDku6_yc6XS7wRGeFOehQjXreqPp6RDW26XGHZCeYGHU6lOA-Qe7x-44_gjOwmv7kqjxxoFGIhyHiij86UZhUOFvkkaAzXaTUoo0iLgasFQlKeQxeigmfSoXAE600Jc-kYkOBuXxiGo3gACJka7febdLKrAAm-xny7GR8GZuYjFdPST9d174cf79_iIQzB2ZKNf7zgPT4m3_SASlGvWq686E-B0vPnwqkDi06wKtRXzDEMMQc1EqME5tmeKTz1I3UV4PaZey38tKLA";
+  const placeholderKeywords = ["IA", "Modelo", "Documento", "Análisis", "Extracción"];
+  const items = hasKeywords ? keywords : placeholderKeywords;
+
+  return (
+    <aside className="w-full lg:w-[360px]">
+      <h2 className="text-textPrimary text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">
+        Palabras Clave
+      </h2>
+      {!hasKeywords && (
+        <div className="flex flex-col px-4 py-6">
+          <div className="flex flex-col items-center gap-6">
+            <div
+              className="bg-center bg-no-repeat aspect-video bg-cover rounded-xl w-full max-w-[360px]"
+              style={{ backgroundImage: `url(${defaultImage})` }}
+            ></div>
+            <div className="flex max-w-[480px] flex-col items-center gap-2">
+              <p className="text-textPrimary text-lg font-bold leading-tight tracking-[-0.015em] text-center">
+                Sube un documento para ver las palabras clave
+              </p>
+              <p className="text-textSecondary text-sm font-normal leading-normal text-center">
+                Las palabras clave se extraerán automáticamente utilizando un modelo de IA.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+      <div className="flex gap-3 p-3 flex-wrap pr-4">
+        {items.map((tag) => (
+          <div
+            key={tag}
+            className="flex h-8 shrink-0 items-center justify-center gap-x-2 rounded-full bg-surface1 pl-4 pr-4"
+          >
+            <p className="text-textPrimary text-sm font-medium leading-normal">{tag}</p>
+          </div>
+        ))}
+      </div>
+    </aside>
+  );
+}

--- a/src/components/UploadDropzone.tsx
+++ b/src/components/UploadDropzone.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState, DragEvent } from "react";
+
+interface UploadDropzoneProps {
+  onFileUpload: (file: File) => void;
+}
+
+export default function UploadDropzone({ onFileUpload }: UploadDropzoneProps) {
+  const [isOver, setIsOver] = useState(false);
+
+  const handleDrag = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    if (e.type === "dragenter" || e.type === "dragover") {
+      setIsOver(true);
+    } else if (e.type === "dragleave") {
+      setIsOver(false);
+    }
+  };
+
+  const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsOver(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) {
+      onFileUpload(file);
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      onFileUpload(file);
+    }
+  };
+
+  return (
+    <div
+      onDragEnter={handleDrag}
+      onDragOver={handleDrag}
+      onDragLeave={handleDrag}
+      onDrop={handleDrop}
+      className={`flex flex-col items-center gap-6 rounded-xl border-2 border-dashed px-6 py-14 transition-colors ${
+        isOver ? "border-textSecondary" : "border-borderDashed"
+      }`}
+      role="region"
+      aria-label="Carga de PDF"
+    >
+      <div className="flex max-w-[480px] flex-col items-center gap-2">
+        <p className="text-lg font-bold leading-tight tracking-[-0.015em] text-textPrimary text-center">
+          Arrastra y suelta un PDF aquí
+        </p>
+        <p className="text-sm font-normal leading-normal text-textPrimary text-center">O</p>
+      </div>
+      <label className="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-surface1 text-textPrimary text-sm font-bold leading-normal tracking-[0.015em] hover:opacity-95 focus-within:outline-none focus-within:ring-2 focus-within:ring-textPrimary/30">
+        <span className="truncate">Seleccionar un archivo</span>
+        <input
+          type="file"
+          accept="application/pdf"
+          onChange={handleChange}
+          className="hidden"
+        />
+      </label>
+    </div>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,16 +3,16 @@ import forms from "@tailwindcss/forms";
 import containerQueries from "@tailwindcss/container-queries";
 
 const config: Config = {
-  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
+  content: ["./src/app/**/*.{ts,tsx}", "./src/components/**/*.{ts,tsx}"],
   theme: {
     extend: {
       colors: {
-        primary: "#1976d2",
-        surface1: "#121212",
-        surface2: "#1e1e1e",
-        textPrimary: "#ffffff",
-        textSecondary: "#b3b3b3",
-        borderDashed: "#ccc"
+        primary: "#181111",
+        surface1: "#382929",
+        surface2: "#533c3d",
+        textPrimary: "#FFFFFF",
+        textSecondary: "#b89d9f",
+        borderDashed: "#533c3d",
       },
       fontFamily: {
         sans: ["Spline Sans", "Noto Sans", "sans-serif"],


### PR DESCRIPTION
## Summary
- define DocuMind color tokens in Tailwind config
- add reusable Header, UploadDropzone and KeywordPanel
- rebuild analyze page with simulated keyword extraction

## Testing
- `yarn lint`
- `yarn build` *(fails: Cannot find module 'tailwindcss')*


------
https://chatgpt.com/codex/tasks/task_e_68ade1f084408330b7495a75b782843b