### PR TITLE
feat(theme): add text field design tokens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.cdnfonts.com/css/gotham');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -13,11 +13,19 @@ const theme = createTheme({
     text: {
       primary: "#FFFFFF",
       secondary: "#b89d9f",
+      disabled: "rgba(255, 255, 255, 0.3)",
+    },
+    error: {
+      main: "#FF4D4D",
     },
     divider: "#382929",
+    action: {
+      hover: "#4b3a3a",
+      disabledBackground: "#533c3d",
+    },
   },
   typography: {
-    fontFamily: '"Spline Sans","Noto Sans",sans-serif',
+    fontFamily: '"Gotham","Spline Sans","Noto Sans",sans-serif',
   },
   components: {
     MuiButton: {
@@ -48,6 +56,81 @@ const theme = createTheme({
           borderRadius: "16px",
           backgroundColor: "#382929",
         },
+      },
+    },
+    MuiTextField: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          '& .MuiOutlinedInput-root': {
+            borderRadius: 8,
+            fontFamily: theme.typography.fontFamily,
+          },
+        }),
+      },
+    },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          borderRadius: 8,
+          backgroundColor: theme.palette.background.paper,
+          color: theme.palette.text.primary,
+          '& .MuiOutlinedInput-notchedOutline': {
+            borderColor: theme.palette.divider,
+          },
+          '&:hover .MuiOutlinedInput-notchedOutline': {
+            borderColor: theme.palette.action.hover,
+          },
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+            borderColor: theme.palette.text.primary,
+          },
+          '&.Mui-error .MuiOutlinedInput-notchedOutline': {
+            borderColor: theme.palette.error.main,
+          },
+          '&.Mui-disabled': {
+            backgroundColor: theme.palette.action.disabledBackground,
+            color: theme.palette.text.disabled,
+            '& .MuiOutlinedInput-notchedOutline': {
+              borderColor: theme.palette.action.disabledBackground,
+            },
+          },
+        }),
+        input: ({ theme }) => ({
+          '&::placeholder': {
+            color: theme.palette.text.secondary,
+            opacity: 1,
+          },
+        }),
+      },
+    },
+    MuiInputLabel: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          color: theme.palette.text.secondary,
+          fontFamily: theme.typography.fontFamily,
+          '&.Mui-focused': {
+            color: theme.palette.text.primary,
+          },
+          '&.Mui-error': {
+            color: theme.palette.error.main,
+          },
+          '&.Mui-disabled': {
+            color: theme.palette.text.disabled,
+          },
+        }),
+      },
+    },
+    MuiFormHelperText: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          color: theme.palette.text.secondary,
+          fontFamily: theme.typography.fontFamily,
+          '&.Mui-error': {
+            color: theme.palette.error.main,
+          },
+          '&.Mui-disabled': {
+            color: theme.palette.text.disabled,
+          },
+        }),
       },
     },
   },


### PR DESCRIPTION
## Summary
- add Gotham font and update theme typography
- apply design token based overrides for TextField components

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a1c413088330a4619cba1c7ec293